### PR TITLE
Fix build and test warnings

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -83,7 +83,7 @@ impl IntoIterator for Color {
     type IntoIter = std::array::IntoIter<f32, 3>;
 
     fn into_iter(self) -> Self::IntoIter {
-        std::array::IntoIter::new([self.r, self.g, self.b])
+        [self.r, self.g, self.b].into_iter()
     }
 }
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -117,11 +117,7 @@ mod test {
 
     #[test]
     fn test_is_close_float() {
-        assert!((EPSILON * 1e-1 + 1.0).is_close(1.0))
-    }
-
-    #[test]
-    fn test_neg_is_close_float() {
+        assert!((EPSILON * 1e-1 + 1.0).is_close(1.0));
         assert!(!(EPSILON + 1.0).is_close(1.0))
     }
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -63,17 +63,17 @@ impl Mul<f32> for Color {
 }
 
 pub trait IsClose<Rhs = Self> {
-    fn is_close(self, other: Self) -> bool;
+    fn is_close(&self, other: Self) -> bool;
 }
 
 impl IsClose for f32 {
-    fn is_close(self, other: f32) -> bool {
+    fn is_close(&self, other: f32) -> bool {
         (self - other).abs() < EPSILON
     }
 }
 
 impl IsClose for Color {
-    fn is_close(self, other: Color) -> bool {
+    fn is_close(&self, other: Color) -> bool {
         self.r.is_close(other.r) & self.g.is_close(other.g) & self.b.is_close(other.b)
     }
 }

--- a/src/hdrimage.rs
+++ b/src/hdrimage.rs
@@ -1,12 +1,12 @@
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use image::{DynamicImage, ImageFormat, Rgb, Rgba};
 use std::fs::File;
-use std::io::{BufRead, BufReader, BufWriter, Cursor, Write};
+use std::io::{BufRead, BufReader, BufWriter, Write};
 use std::path::Path;
 use std::str::FromStr;
 use std::vec::Vec;
 
-use crate::color::{Color, IsClose};
+use crate::color::Color;
 use crate::error::HdrImageErr;
 
 const DELTA: f32 = 1e-10;
@@ -280,6 +280,8 @@ fn clamp(x: f32) -> f32 {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::io::Cursor;
+    use crate::color::IsClose;
 
     #[test]
     fn test_image_creation() {

--- a/src/hdrimage.rs
+++ b/src/hdrimage.rs
@@ -338,37 +338,37 @@ mod test {
     fn test_parse_img_shape() {
         let mut line = "10 20";
 
-        assert!(matches!(parse_img_shape(&line), Ok((10, 20))));
+        assert!(matches!(parse_img_shape(line), Ok((10, 20))));
         line = " 10    20  ";
-        assert!(matches!(parse_img_shape(&line), Ok((10, 20))));
+        assert!(matches!(parse_img_shape(line), Ok((10, 20))));
         line = "10 20 30";
         assert!(matches!(
-            parse_img_shape(&line),
+            parse_img_shape(line),
             Err(HdrImageErr::InvalidPfmFileFormat(_))
         ));
         line = "10 ";
         assert!(matches!(
-            parse_img_shape(&line),
+            parse_img_shape(line),
             Err(HdrImageErr::InvalidPfmFileFormat(_))
         ));
         line = "102030";
         assert!(matches!(
-            parse_img_shape(&line),
+            parse_img_shape(line),
             Err(HdrImageErr::InvalidPfmFileFormat(_))
         ));
         line = "10 20.1";
         assert!(matches!(
-            parse_img_shape(&line),
+            parse_img_shape(line),
             Err(HdrImageErr::PfmIntParseFailure(_, msg)) if msg.as_str() == "image height"
         ));
         line = "-10 20";
         assert!(matches!(
-            parse_img_shape(&line),
+            parse_img_shape(line),
             Err(HdrImageErr::PfmIntParseFailure(_, msg)) if msg.as_str() == "image width"
         ));
         line = "abc 20";
         assert!(matches!(
-            parse_img_shape(&line),
+            parse_img_shape(line),
             Err(HdrImageErr::PfmIntParseFailure(_, msg)) if msg.as_str() == "image width"
         ))
     }
@@ -378,19 +378,19 @@ mod test {
         let mut line = "-3.2";
 
         assert!(matches!(
-            parse_endianness(&line),
+            parse_endianness(line),
             Ok(ByteOrder::LittleEndian)
         ));
         line = "1e15";
-        assert!(matches!(parse_endianness(&line), Ok(ByteOrder::BigEndian)));
+        assert!(matches!(parse_endianness(line), Ok(ByteOrder::BigEndian)));
         line = "0";
         assert!(matches!(
-            parse_endianness(&line),
+            parse_endianness(line),
             Err(HdrImageErr::InvalidPfmFileFormat(_))
         ));
         line = "abc";
         assert!(matches!(
-            parse_endianness(&line),
+            parse_endianness(line),
             Err(HdrImageErr::PfmFloatParseFailure(..))
         ));
     }
@@ -599,27 +599,27 @@ mod test {
         let invalid_file = Path::new("/tmp/invalid");
 
         assert!(matches!(
-            hdr_img.write_pfm_file(&reference_file_be, ByteOrder::BigEndian),
+            hdr_img.write_pfm_file(reference_file_be, ByteOrder::BigEndian),
             Ok(())
         ));
         assert!(matches!(
-            hdr_img.write_pfm_file(&reference_file_le, ByteOrder::LittleEndian),
+            hdr_img.write_pfm_file(reference_file_le, ByteOrder::LittleEndian),
             Ok(())
         ));
         assert!(matches!(
-            hdr_img.write_pfm_file(&invalid_path, ByteOrder::LittleEndian),
+            hdr_img.write_pfm_file(invalid_path, ByteOrder::LittleEndian),
             Err(std::io::Error { .. })
         ));
 
-        let hdr_img_result = HdrImage::read_pfm_file(&reference_file_be);
+        let hdr_img_result = HdrImage::read_pfm_file(reference_file_be);
         assert!(matches!(hdr_img_result, Ok(ref img) if img == &hdr_img));
         assert_eq!(hdr_img_result.unwrap(), hdr_img);
 
-        let hdr_img_result = HdrImage::read_pfm_file(&reference_file_le);
+        let hdr_img_result = HdrImage::read_pfm_file(reference_file_le);
         assert!(matches!(hdr_img_result, Ok(ref img) if img == &hdr_img));
         assert_eq!(hdr_img_result.unwrap(), hdr_img);
 
-        let hdr_img_result = HdrImage::read_pfm_file(&invalid_file);
+        let hdr_img_result = HdrImage::read_pfm_file(invalid_file);
         assert!(matches!(
             hdr_img_result,
             Err(HdrImageErr::PfmFileReadFailure(_))
@@ -676,7 +676,7 @@ mod test {
         hdr_img.clamp_image();
         for pixel in hdr_img.pixels.iter() {
             for el in pixel.into_iter() {
-                assert!(el >= 0.0 && el < 1.0);
+                assert!((0.0..1.0).contains(&el));
             }
         }
     }
@@ -703,21 +703,21 @@ mod test {
         let reference_ff = Path::new("/tmp/reference_le.ff");
 
         assert!(matches!(
-            hdr_img.write_ldr_file(&invalid_format, 1.0),
+            hdr_img.write_ldr_file(invalid_format, 1.0),
             Err(HdrImageErr::LdrFileWriteFailure(_))
         ));
         assert!(matches!(
-            hdr_img.write_ldr_file(&unsupported_format, 1.0),
+            hdr_img.write_ldr_file(unsupported_format, 1.0),
             Err(HdrImageErr::UnsupportedLdrFileFormat(format)) if format.as_str() == "jpeg"
         ));
         assert!(matches!(
-            hdr_img.write_ldr_file(&invalid_path, 1.0),
+            hdr_img.write_ldr_file(invalid_path, 1.0),
             Err(HdrImageErr::LdrFileWriteFailure(_))
         ));
         assert!(matches!(
-            hdr_img.write_ldr_file(&reference_png, 1.0),
+            hdr_img.write_ldr_file(reference_png, 1.0),
             Ok(())
         ));
-        assert!(matches!(hdr_img.write_ldr_file(&reference_ff, 1.0), Ok(())))
+        assert!(matches!(hdr_img.write_ldr_file(reference_ff, 1.0), Ok(())))
     }
 }

--- a/src/hdrimage.rs
+++ b/src/hdrimage.rs
@@ -280,8 +280,8 @@ fn clamp(x: f32) -> f32 {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::io::Cursor;
     use crate::color::IsClose;
+    use std::io::Cursor;
 
     #[test]
     fn test_image_creation() {
@@ -315,7 +315,7 @@ mod test {
     fn test_get_pixel() {
         let color: Color = Default::default();
 
-        assert!(matches!(HdrImage::new(3, 3).get_pixel(0, 0), Ok(color)));
+        assert!(matches!(HdrImage::new(3, 3).get_pixel(0, 0), Ok(col) if col == color));
         assert!(matches!(HdrImage::new(3, 3).get_pixel(3, 3),
             Err(HdrImageErr::OutOfBounds(a, b)) if a == (3, 3) && b == (3, 3)))
     }
@@ -328,7 +328,7 @@ mod test {
         let mut hdr_img = HdrImage::new(3, 3);
         assert!(matches!(hdr_img.set_pixel(0, 0, color1), Ok(())));
         assert!(matches!(hdr_img.set_pixel(2, 2, color2), Ok(())));
-        assert!(matches!(hdr_img.get_pixel(0, 0), Ok(color1)));
+        assert!(matches!(hdr_img.get_pixel(0, 0), Ok(col1) if col1 == color1));
         assert!(hdr_img.get_pixel(2, 2).unwrap().is_close(color2));
         assert!(matches!(hdr_img.set_pixel(5, 5, color1),
             Err(HdrImageErr::OutOfBounds(a, b)) if a == (5, 5) && b == (3, 3)))
@@ -359,17 +359,17 @@ mod test {
         line = "10 20.1";
         assert!(matches!(
             parse_img_shape(&line),
-            Err(HdrImageErr::PfmIntParseFailure(e, msg)) if msg.as_str() == "image height"
+            Err(HdrImageErr::PfmIntParseFailure(_, msg)) if msg.as_str() == "image height"
         ));
         line = "-10 20";
         assert!(matches!(
             parse_img_shape(&line),
-            Err(HdrImageErr::PfmIntParseFailure(e, msg)) if msg.as_str() == "image width"
+            Err(HdrImageErr::PfmIntParseFailure(_, msg)) if msg.as_str() == "image width"
         ));
         line = "abc 20";
         assert!(matches!(
             parse_img_shape(&line),
-            Err(HdrImageErr::PfmIntParseFailure(e, msg)) if msg.as_str() == "image width"
+            Err(HdrImageErr::PfmIntParseFailure(_, msg)) if msg.as_str() == "image width"
         ))
     }
 
@@ -437,12 +437,12 @@ mod test {
 
         let mut stream = Cursor::new(reference_bytes_be);
         let hdr_img_result = HdrImage::read_pfm_image(&mut stream);
-        assert!(matches!(hdr_img_result, Ok(ref hdr_img)));
+        assert!(matches!(hdr_img_result, Ok(ref img) if img == &hdr_img));
         assert_eq!(&hdr_img_result.unwrap(), &hdr_img);
 
         let mut stream = Cursor::new(&reference_bytes_le);
         let hdr_img_result = HdrImage::read_pfm_image(&mut stream);
-        assert!(matches!(hdr_img_result, Ok(ref hdr_img)));
+        assert!(matches!(hdr_img_result, Ok(ref img) if img == &hdr_img));
         assert_eq!(&hdr_img_result.unwrap(), &hdr_img);
 
         let wrong_magic = vec![0x46, 0x50, 0x0a];
@@ -566,7 +566,7 @@ mod test {
         ));
         stream.set_position(0);
         let hdr_img_result = HdrImage::read_pfm_image(&mut stream);
-        assert!(matches!(hdr_img_result, Ok(ref hdr_img)));
+        assert!(matches!(hdr_img_result, Ok(ref img) if img == &hdr_img));
         assert_eq!(hdr_img_result.unwrap(), hdr_img);
     }
 
@@ -612,11 +612,11 @@ mod test {
         ));
 
         let hdr_img_result = HdrImage::read_pfm_file(&reference_file_be);
-        assert!(matches!(hdr_img_result, Ok(ref hdr_img)));
+        assert!(matches!(hdr_img_result, Ok(ref img) if img == &hdr_img));
         assert_eq!(hdr_img_result.unwrap(), hdr_img);
 
         let hdr_img_result = HdrImage::read_pfm_file(&reference_file_le);
-        assert!(matches!(hdr_img_result, Ok(ref hdr_img)));
+        assert!(matches!(hdr_img_result, Ok(ref img) if img == &hdr_img));
         assert_eq!(hdr_img_result.unwrap(), hdr_img);
 
         let hdr_img_result = HdrImage::read_pfm_file(&invalid_file);

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use crate::hdrimage::{HdrImage, Luminosity};
 fn main() {
     let cli_m = cli::build_cli().get_matches_from(env::args_os());
     match cli_m.subcommand_name() {
-        Some("convert") => match convert(&cli_m.subcommand_matches("convert").unwrap()) {
+        Some("convert") => match convert(cli_m.subcommand_matches("convert").unwrap()) {
             Ok(()) => exit(0),
             Err(e) => {
                 eprintln!("[error] {:#}", e);
@@ -32,7 +32,7 @@ fn convert(sub_m: &clap::ArgMatches) -> Result<(), ConvertErr> {
         .map_err(|e| ConvertErr::FloatParseFailure(e, String::from("factor")))?;
     let gamma = f32::from_str(sub_m.value_of("gamma").unwrap())
         .map_err(|e| ConvertErr::FloatParseFailure(e, String::from("gamma")))?;
-    let mut hdr_img = HdrImage::read_pfm_file(hdr_file).map_err(|e| ConvertErr::IoError(e))?;
+    let mut hdr_img = HdrImage::read_pfm_file(hdr_file).map_err(ConvertErr::IoError)?;
     if sub_m.is_present("verbose") {
         println!("[info] {:?} has been read from disk", hdr_file);
     }
@@ -40,7 +40,7 @@ fn convert(sub_m: &clap::ArgMatches) -> Result<(), ConvertErr> {
     hdr_img.clamp_image();
     hdr_img
         .write_ldr_file(ldr_file, gamma)
-        .map_err(|e| ConvertErr::IoError(e))?;
+        .map_err(ConvertErr::IoError)?;
     if sub_m.is_present("verbose") {
         println!("[info] {:?} has been written to disk", ldr_file);
     }


### PR DESCRIPTION
Hello

fix warnings during build process (also unit tests) and lint using `clippy` to fix additional error-warning

The remaining build warnings are relative to some unused pub methods, only future will tell us if will be used or not inside `main.rs`

All 20 unit tests passed 🟢 