### PR TITLE
build(ci/cd): refresh `ci` workflow and add `cd` workflow

### DIFF
--- a/.github/workflows/cd.sh
+++ b/.github/workflows/cd.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# `rustracer` continuos deployment workflow (`cd.yml`) helper script,
+# it assemble, checksum and (co)sign artifacts for releases
+
 set -e
 
 GNU="rustracer-${GITHUB_REF_NAME}-x86_64-unknown-linux-gnu"

--- a/.github/workflows/cd.sh
+++ b/.github/workflows/cd.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -e
+
+GNU="rustracer-${GITHUB_REF_NAME}-x86_64-unknown-linux-gnu"
+MUSL="rustracer-${GITHUB_REF_NAME}-x86_64-unknown-linux-musl"
+SUM="rustracer-${GITHUB_REF_NAME}_checksums_sha256.txt"
+
+_assemble() {
+   mkdir -pv "${GNU}/bin"
+   mkdir -pv "${MUSL}/bin"
+   cp -v target/release/rustracer \
+      "${GNU}/bin/rustracer"
+   cp -v target/x86_64-unknown-linux-musl/release/rustracer \
+      "${MUSL}/bin/rustracer"
+   cp -v {README.md,LICENSE} "${GNU}/"
+   cp -v {README.md,LICENSE} "${MUSL}/"
+   tar czfv "${GNU}.tar.gz" "${GNU}"
+   tar czfv "${MUSL}.tar.gz" "${MUSL}"
+   sha256sum ./*.tar.gz > "${SUM}"
+}
+
+_cosign() {
+   for blob in "${GNU}.tar.gz" "${MUSL}.tar.gz" "${SUM}"
+   do
+      cosign sign-blob "${blob}" \
+         --output-signature "${blob}-keyless.sig" \
+         --output-certificate "${blob}-keyless.pem"
+   done
+}
+
+case $1 in
+   assemble) _assemble;;
+   cosign)   _cosign;;
+   *)        echo "cd.sh (assemble|cosign)";;
+esac

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,123 @@
+---
+name: CD
+
+"on":
+  push:
+    tags:
+      - "[0-9].[0-9].[0-9]+$"
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: checkout project
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+      - name: check cargo cache
+        uses: actions/cache@4b0cf6cc4619e737324ddfcec08fff2413359514
+        id: rust-cache
+        with:
+          path: |
+            ~/.cargo/
+            ~/.rustup/
+            target/
+          key: ${{ runner.os }}-rust-musl-${{ hashFiles('Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}
+      - name: install rust toolchain
+        if: steps.rust-cache.outputs.cache-hit != 'true'
+        uses: actions-rs/toolchain@56751392ac172fc3a68fef1413f507767ed5f563
+        with:
+          toolchain: stable
+          default: true
+          profile: minimal
+          target: x86_64-unknown-linux-musl
+      - name: cargo release gnu
+        uses: actions-rs/cargo@b0651d9f4d4983fd4cc8e94d927bdc0bb5566667
+        with:
+          command: build
+          args: --locked --release
+      - name: cargo release musl
+        uses: actions-rs/cargo@b0651d9f4d4983fd4cc8e94d927bdc0bb5566667
+        with:
+          command: build
+          args: --locked --release --target x86_64-unknown-linux-musl
+      - name: assemble artifacts
+        run: .github/workflows/cd.sh assemble
+      - name: check cosign version
+        id: cosign-version
+        run: |
+          LATEST=$(curl -sL https://api.github.com/repos/sigstore/cosign/releases/latest | jq -r ".tag_name")
+          echo "cosign version: ${LATEST}"
+          echo "##[set-output name=latest;]${LATEST}"
+      - name: check cosign cache
+        uses: actions/cache@4b0cf6cc4619e737324ddfcec08fff2413359514
+        id: cosign-cache
+        with:
+          path: ~/.cosign
+          key: ${{ runner.os }}-cosign-${{ steps.cosign-version.outputs.latest }}
+      - name: install cosign
+        if: steps.cosign-cache.outputs.cache-hit != 'true'
+        uses: sigstore/cosign-installer@372f03d876de9bfec5079d00fc6cd2485af9a026
+      - name: cosign artifacts
+        env:
+          COSIGN_EXPERIMENTAL: 1
+        run: .github/workflows/cd.sh cosign
+      - name: release artifacts
+        uses: softprops/action-gh-release@6232f0b438cb856c39d14f8743e3a7c99fc879af
+        with:
+          name: rustracer ${GITHUB_REF_NAME}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            rustracer-${GITHUB_REF_NAME}-x86_64-unknown-linux-*.tar.gz
+            rustracer-${GITHUB_REF_NAME}-x86_64-unknown-linux-*.tar.gz-keyless.pem
+            rustracer-${GITHUB_REF_NAME}-x86_64-unknown-linux-*.tar.gz-keyless.sig
+            rustracer-${GITHUB_REF_NAME}_checksums_sha256.txt
+            rustracer-${GITHUB_REF_NAME}_checksums_sha256.txt-keyless.pem
+            rustracer-${GITHUB_REF_NAME}_checksums_sha256.txt-keyless.sig
+  ghpages:
+    name: ghpages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs:
+      - release
+    steps:
+      - name: checkout project
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+      - name: check cache
+        uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09
+        id: cache
+        with:
+          path: |
+            ~/.cargo/
+            ~/.rustup/
+            target/
+          key: ${{ runner.os }}-rust-all-${{ hashFiles('Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}
+      - name: install rust toolchain
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions-rs/toolchain@568dc894a7f9e32ffd9bb7d7a6cebb784cdaa2b0
+        with:
+          toolchain: stable
+          default: true
+          profile: minimal
+          components: clippy, llvm-tools-preview, rustfmt, rust-docs
+      - name: cargo rustdoc
+        uses: actions-rs/cargo@b0651d9f4d4983fd4cc8e94d927bdc0bb5566667
+        with:
+          command: rustdoc
+      - name: patch docs
+        run: |
+          for file in $(ls -1 target/doc/rustracer)
+          do
+            ln -sf rustracer/$file target/doc/$file
+          done
+          cp install.sh target/doc/
+      - name: publish to gh-pages
+        uses: peaceiris/actions-gh-pages@b24891da2a683970a75ebe54633f084809cc25c0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: target/doc/

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -78,13 +78,50 @@ jobs:
             rustracer-${GITHUB_REF_NAME}_checksums_sha256.txt
             rustracer-${GITHUB_REF_NAME}_checksums_sha256.txt-keyless.pem
             rustracer-${GITHUB_REF_NAME}_checksums_sha256.txt-keyless.sig
+  #cratesio:
+    #name: cratesio
+    #runs-on: ubuntu-latest
+    #environment:
+      #name: cratesio
+      #url: https://crates.io/crates/rustracer
+    #permissions:
+      #contents: read
+    #needs:
+      #- release
+    #steps:
+      #- name: checkout project
+        #uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+      #- name: check cache
+        #uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09
+        #id: cache
+        #with:
+          #path: |
+            #~/.cargo/
+            #~/.rustup/
+            #target/
+          #key: ${{ runner.os }}-rust-all-${{ hashFiles('Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}
+      #- name: install rust toolchain
+        #if: steps.cache.outputs.cache-hit != 'true'
+        #uses: actions-rs/toolchain@568dc894a7f9e32ffd9bb7d7a6cebb784cdaa2b0
+        #with:
+          #toolchain: stable
+          #default: true
+          #profile: minimal
+          #components: clippy, llvm-tools-preview, rustfmt, rust-docs
+      #- name: cargo publish
+        #uses: actions-rs/cargo@b0651d9f4d4983fd4cc8e94d927bdc0bb5566667
+        #with:
+          #command: publish
+          #args: --locked
+        #env:
+          #CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
   ghpages:
     name: ghpages
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs:
-      - release
+    #needs:
+      #- cratesio
     steps:
       - name: checkout project
         uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -147,12 +147,7 @@ jobs:
         with:
           command: rustdoc
       - name: patch docs
-        run: |
-          for file in $(ls -1 target/doc/rustracer)
-          do
-            ln -sf rustracer/$file target/doc/$file
-          done
-          cp install.sh target/doc/
+        run: make patch_docs
       - name: publish to gh-pages
         uses: peaceiris/actions-gh-pages@b24891da2a683970a75ebe54633f084809cc25c0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,17 +5,9 @@ name: CI
   push:
     branches:
       - master
-    paths:
-      - 'Cargo.lock'
-      - 'Cargo.toml'
-      - 'src/**'
   pull_request:
     branches:
       - master
-    paths:
-      - 'Cargo.lock'
-      - 'Cargo.toml'
-      - 'src/**'
 
 jobs:
   pre_ci:
@@ -32,8 +24,31 @@ jobs:
           REPO_NAME=${GITHUB_REPOSITORY#$GITHUB_REPOSITORY_OWNER/}
           echo "Repo: ${REPO_NAME}"
           echo "##[set-output name=repo;]${REPO_NAME}"
-  lint:
-    name: lint ci
+  changes:
+    name: filter changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      bash: ${{ steps.filter.outputs.bash }}
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - name: checkout project
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721
+        id: filter
+        with:
+          filters: |
+            bash:
+              - '**/*.sh'
+            rust:
+              - '**/*.rs'
+              - 'Cargo.lock'
+              - 'Cargo.toml'
+  lint_rs:
+    name: lint rust ci
+    needs: changes
+    if: ${{ needs.changes.outputs.rust == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -76,9 +91,23 @@ jobs:
         uses: actions-rs/cargo@4ff6ec2846f6e7217c1a9b0b503506665f134c4b
         with:
           command: rustdoc
+  lint_sh:
+    name: lint bash ci
+    needs: changes
+    if: ${{ needs.changes.outputs.bash == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: checkout project
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: shellcheck bash
+        run: |
+          shopt -s globstar
+          shellcheck -s bash **/*.sh .github/**/*.sh
   test:
     name: test ci
-    needs: lint
+    needs: lint_rs
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -124,8 +153,9 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         id: coverage
         run: |
-          COVERAGE=$(cat coverage.json | \
-                     jq -r ".data[0] | .totals | .lines | .percent" | awk '{print int($0)}')
+          COVERAGE=$(cat coverage.json \
+             | jq -r ".data[0] | .totals | .lines | .percent" \
+             | awk '{print int($0)}')
           echo "##[set-output name=coverage;]${COVERAGE}"
       - name: cargo test coverage (lcov)
         if: ${{ github.event_name == 'pull_request' }}

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# end-user `rustracer` installation script:
+#  * downloads particular release (default `latest+musl`)
+#  * downloads related checksum and signatures
+#  * controls related  checksum and signatures
+#  * installs inside given $PREFIX (default `~/.local`)
+
 set -e
 
 os=$(uname -s)

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+set -e
+
+os=$(uname -s)
+arch=$(uname -m)
+libc=${1:-musl}
+version=${2:-latest}
+platform="${arch}-unknown-${os,,}-${libc}"
+PREFIX=${PREFIX-$HOME/.local}
+
+_die() {
+   printf '[Error] %s\n' "$@" >&2
+   exit 1
+}
+_info() {
+   printf '[Info] %s\n' "$@"
+}
+
+_check_deps() {
+   local deps
+   deps=(curl jq openssl)
+   for dep in "${deps[@]}"
+   do
+      type "$dep" >/dev/null 2>&1 || {
+         _die "Cannot find ${dep} in your \$PATH" \
+              "Install rustracer manually or install ${dep}"
+      }
+   done
+}
+
+_download_release() {
+   local checksums_uri
+   local rustracer_uri
+   local repo="https://github.com/andros21/rustracer"
+   local repo_api="https://api.github.com/repos/andros21/rustracer"
+   if [ "${version}" == "latest" ]
+   then
+      checksums_uri=$(curl -sL "${repo_api}/releases/latest" \
+         | jq -r ".assets[] | select(.name | test(\"_checksums_sha256.txt\$\")) | .browser_download_url")
+      rustracer_uri=$(curl -sL "${repo_api}/releases/latest" \
+         | jq -r ".assets[] | select(.name | test(\"${platform}.tar.gz\$\")) | .browser_download_url")
+   else
+      curl -sL "${repo_api}/releases" \
+         | jq -r ".[] | select(.tag_name | test(\"${version}\$\"))" \
+         | grep -qF "${version}" \
+         || _die "Invalid rustracer version ${version}" \
+                 "see available at ${repo}/releases"
+      checksums_uri="${repo}/releases/download/${version}/rustracer-${version}_checksums_sha256.txt"
+      rustracer_uri=$(curl -sL "${repo_api}/releases" \
+         | jq -r ".[] | select(.tag_name | test(\"${version}\$\"))" \
+         | jq -r ".assets[] | select(.name | test(\"${platform}.tar.gz\$\")) | .browser_download_url")
+   fi
+   [[ -n "${rustracer_uri}" ]] \
+      || _die "Invalid rustracer platform ${platform}" \
+              "see available at ${repo}/releases"
+   checksums="$(basename "${checksums_uri}")"
+   rustracer="$(basename "${rustracer_uri}")"
+   _info "Downloading rustracer ${version} checksums"
+   [[ -f "${checksums}" ]]             || curl -sSJOL "${checksums_uri}"
+   [[ -f "${checksums}-keyless.pem" ]] || curl -sSJOL "${checksums_uri}-keyless.pem"
+   [[ -f "${checksums}-keyless.sig" ]] || curl -sSJOL "${checksums_uri}-keyless.sig"
+   _info "Downloading rustracer ${version} for platform ${platform}"
+   [[ -f "${rustracer}" ]]             || curl -sSJOL "${rustracer_uri}"
+   [[ -f "${rustracer}-keyless.pem" ]] || curl -sSJOL "${rustracer_uri}-keyless.pem"
+   [[ -f "${rustracer}-keyless.sig" ]] || curl -sSJOL "${rustracer_uri}-keyless.sig"
+}
+
+_verify_release() {
+   _info "Verifying   rustracer ${version} checksums signature"
+   openssl dgst -sha256 -out /dev/null \
+      -verify <(base64 -d "${checksums}-keyless.pem" | openssl x509 -pubkey -noout 2>/dev/null) \
+      -signature <(base64 -d "${checksums}-keyless.sig") \
+      "${checksums}" && rm -f "${checksums}-keyless".{sig,pem}
+   _info "Verifying   rustracer ${version} for platform ${platform} checksum"
+   sha256sum -c --quiet --ignore-missing "${checksums}" && rm -f "${checksums}"
+   _info "Verifying   rustracer ${version} for platform ${platform} signature"
+   openssl dgst -sha256 -out /dev/null \
+      -verify <(base64 -d "${rustracer}-keyless.pem" | openssl x509 -pubkey -noout 2>/dev/null) \
+      -signature <(base64 -d "${rustracer}-keyless.sig") \
+      "${rustracer}" && rm -f "${rustracer}-keyless".{sig,pem}
+}
+
+_install_release() {
+   _info "Installing  rustracer ${version} for platform ${platform}"
+   tar xzf "${rustracer}" && rm -f "${rustracer}"
+   install -Dm755 "${rustracer%.tar.gz}/bin/rustracer" "${PREFIX}/bin/rustracer" \
+      && _info "rustracer was installed successfully to ${PREFIX}/bin/rustracer"
+}
+
+_check_deps
+_download_release
+_verify_release
+_install_release
+if type rustracer >/dev/null 2>&1
+then
+   printf "\nRun 'rustracer --help' to get started\n"
+else
+   printf "\nManually add %s/bin to your \$PATH\n" "${PREFIX}"
+   printf "Run 'rustracer --help' to get started\n"
+fi

--- a/makefile
+++ b/makefile
@@ -16,11 +16,14 @@ examples/demo:
 	@ffmpeg -loglevel panic -f image2 -framerate 25 -i $@/frames/frame-%03d.png $@/demo.gif
 	@printf "done\n"
 
-docs: docs.pid
+docs: patch_docs docs.pid
 ccov: ccov.pid
 
-docs.pid:
+patch_docs:
 	@for f in `ls -1 target/doc/rustracer`; do ln -sf rustracer/$$f target/doc/$$f; done;
+	@cp install.sh target/doc/
+
+docs.pid:
 	@printf "starting http.server ... "
 	@{ python3 -m http.server -b 127.0.0.1 -d target/doc/ 8080 >/dev/null 2>&1 \
 		& echo $$! >$@; }


### PR DESCRIPTION
feat! with an `install.sh` ready to be used by user for bin installation from github releases