### PR TITLE
build(README): automatic console help update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
       interval: "weekly"
       day: "sunday"
     rebase-strategy: "disabled"
+  - package-ecosystem: "pip"
+    directory: ".github/workflows"
+    schedule:
+      interval: "monthly"
+    rebase-strategy: "disabled"

--- a/.github/workflows/cd.sh
+++ b/.github/workflows/cd.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# cd.sh
+# =====
 # `rustracer` continuos deployment workflow (`cd.yml`) helper script,
 # it assemble, checksum and (co)sign artifacts for releases
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       contents: read
     outputs:
       bash: ${{ steps.filter.outputs.bash }}
+      python: ${{ steps.filter.outputs.python }}
       rust: ${{ steps.filter.outputs.rust }}
     steps:
       - name: checkout project
@@ -41,6 +42,9 @@ jobs:
           filters: |
             bash:
               - '**/*.sh'
+            python:
+              - '**/*.py'
+              - '.github/workflows/requirements.txt'
             rust:
               - '**/*.rs'
               - 'Cargo.lock'
@@ -105,6 +109,24 @@ jobs:
         run: |
           shopt -s globstar
           shellcheck -s bash **/*.sh .github/**/*.sh
+  lint_py:
+    name: lint python ci
+    needs: changes
+    if: ${{ needs.changes.outputs.python == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: checkout project
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: setup python
+        run: |
+          python3 -m pip install --user -r .github/workflows/requirements.txt
+      - name: black/flake python
+        run: |
+          md=".github/workflows/md.py"
+          ~/.local/bin/black "$md"
+          ~/.local/bin/flake8 --max-line-length 90 "$md"
   test:
     name: test ci
     needs: lint_rs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
     outputs:
       bash: ${{ steps.filter.outputs.bash }}
       python: ${{ steps.filter.outputs.python }}
+      md: ${{ steps.filter.outputs.md }}
       rust: ${{ steps.filter.outputs.rust }}
     steps:
       - name: checkout project
@@ -45,6 +46,8 @@ jobs:
             python:
               - '**/*.py'
               - '.github/workflows/requirements.txt'
+            md:
+              - 'TEMPLATE.md'
             rust:
               - '**/*.rs'
               - 'Cargo.lock'
@@ -222,3 +225,21 @@ jobs:
           MARKDOWN="![Coverage](${URL})"
           echo "Badge URL: ${URL}"
           echo "Badge image for Markdown: ${MARKDOWN}"
+  md:
+    name: update readme
+    needs: changes
+    if: ${{ (github.event_name == 'push') && (needs.changes.outputs.md == 'true') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: setup python
+        run: |
+          python3 -m pip install --user -r .github/workflows/requirements.txt
+      - name: update readme
+        run: .github/workflows/md.py
+      - name: commit readme
+        uses: EndBug/add-and-commit@998652d28d7702d095d40f52ae42982a80ae8c7d
+        with:
+          message: 'feat(README): update from README template'
+          add: 'README.md'

--- a/.github/workflows/md.py
+++ b/.github/workflows/md.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+# md.py
+# =========
+# update `README.md` console help output from `TEMPLATE.md`
+
+import subprocess
+
+from jinja2 import Template
+
+if __name__ == "__main__":
+    rustracer = {
+        "rustracer": subprocess.run(
+            "target/release/rustracer -h".split(), capture_output=True, encoding="utf8"
+        ).stdout,
+        "rustracer_convert": subprocess.run(
+            "target/release/rustracer convert -h".split(),
+            capture_output=True,
+            encoding="utf8",
+        ).stdout,
+        "rustracer_demo": subprocess.run(
+            "target/release/rustracer demo -h".split(),
+            capture_output=True,
+            encoding="utf8",
+        ).stdout,
+        "rustracer_render": subprocess.run(
+            "target/release/rustracer render -h".split(),
+            capture_output=True,
+            encoding="utf8",
+        ).stdout,
+        "rustracer_completion": subprocess.run(
+            "target/release/rustracer completion -h".split(),
+            capture_output=True,
+            encoding="utf8",
+        ).stdout,
+    }
+
+    with open("TEMPLATE.md") as ifs:
+        template = Template(ifs.read())
+    with open("README.md", "w") as ofs:
+        ofs.write(template.render(rustracer) + "\n")

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,0 +1,11 @@
+# requirements.txt
+# ================
+
+# cd deps
+# -------
+Jinja2==3.1.2
+
+# ci deps
+# -------
+black==22.6.0
+flake8==4.0.1

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,11 +1,8 @@
 # requirements.txt
 # ================
 
-# cd deps
-# -------
-Jinja2==3.1.2
-
 # ci deps
 # -------
+Jinja2==3.1.2
 black==22.6.0
 flake8==4.0.1

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -1,0 +1,269 @@
+<!-- PROJECT LOGO -->
+<br>
+<div align="center">
+  <a href="https://github.com/andros21/rustracer">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/58751603/176992080-d96e1e43-5309-45cd-968e-76c4ea132dde.png">
+      <img src="https://user-images.githubusercontent.com/58751603/176992080-d96e1e43-5309-45cd-968e-76c4ea132dde.png" alt="Logo" width="470">
+    </picture>
+  </a>
+  <h3 style="border-bottom: 0px;">a multi-threaded raytracer in pure rust</h3>
+  <a href="https://github.com/andros21/rustracer/actions/workflows/ci.yml">
+    <img src="https://img.shields.io/github/workflow/status/andros21/rustracer/CI?style=flat-square&label=ci&logo=github" alt="CI">
+  </a>
+  <a href="https://github.com/andros21/rustracer/actions/workflows/ci.yml">
+    <img src="https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/andros21/0e20cd331d0800e3299298a3868aab7a/raw/rustracer__master.json" alt="Coverage">
+  </a>
+  <a href="https://github.com/andros21/rustracer/actions/workflows/cd.yml">
+    <img src="https://img.shields.io/github/workflow/status/andros21/rustracer/CD?style=flat-square&label=cd&logo=github" alt="CD">
+  </a>
+  <br>
+  <a href="https://github.com/andros21/rustracer/releases">
+    <img src="https://img.shields.io/github/v/release/andros21/rustracer?color=orange&&sort=semver&style=flat-square&logo=github" alt="Version">
+  </a>
+    <a href="https://crates.io/crates/rustracer">
+    <img src="https://img.shields.io/crates/v/rustracer?color=orange&logo=rust&style=flat-square" alt="Cratesio Version">
+  </a>
+  <br>
+  <a href="https://github.com/andros21/rustracer/blob/master/LICENSE">
+    <img src="https://img.shields.io/github/license/andros21/rustracer?color=blue&style=flat-square&logo=gnu" alt="License">
+  </a>
+  <div align="center">
+    <a href="#prerequisites">Prerequisites</a>
+    ·
+    <a href="#installation">Installation</a>
+    ·
+    <a href="#usage">Usage</a>
+  </div>
+</div>
+
+## Prerequisites
+
+### Platform requirements
+
+* `x86_64-unknown-linux-gnu` <a href="#note1"><sup>(1)</sup></a>
+* `x86_64-unknown-linux-musl`
+
+<p id="note1"><sub><strong><sup>(1)</sup> note:</strong> glibc version >= 2.27</sub></p>
+
+### Build requirements
+
+* for **users** install [`cargo`](https://github.com/rust-lang/cargo/) stable latest build system
+
+* for **devels** it's advisable to install the entire (stable latest) toolchain using [`rustup`](https://www.rust-lang.org/tools/install)
+
+   For unit tests coverage `llvm-tools-preview` is required as additional component coupled with\
+   [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) for easily use LLVM source-based code coverage
+
+  There is an handy [`makefile`](https://github.com/andros21/rustracer/blob/master/makefile) useful to:
+    + preview documentation built with `rustdoc`
+    + preview html code coverage analysys created with `cargo-llvm-cov`
+    + create demo animations
+
+## Installation
+
+### From binary
+
+Install from binary:
+
+<h4>
+<code>curl -sSf https://andros21.github.io/rustracer/install.sh | bash</code>&nbsp;&nbsp;<a href="#note2"><sup>(2)</sup></a>
+</h4>
+
+<br>
+<details>
+<summary>click to show other installation options</summary>
+
+```bash
+## Install the latest version `gnu` variant in `~/.rustracer/bin`
+export PREFIX='~/.rustracer/'
+curl -sSf https://andros21.github.io/rustracer/install.sh | bash -s -- gnu
+
+## Install the `0.4.0` version `musl` variant in `~/.rustracer/bin`
+export PREFIX='~/.rustracer/'
+curl -sSf https://andros21.github.io/rustracer/install.sh | bash -s -- musl 0.4.0
+```
+</details>
+
+<p id="note2"><sub><strong><sup>(2)</sup> note:</strong> will install latest musl release in <code>~/.local/bin</code></sub></p>
+
+### From source
+
+Install from source code, a template could be:
+
+<h4>
+   <code> cargo install rustracer</code>&nbsp;&nbsp;<a href="#note3"><sup>(3)</sup></a>
+</h4>
+
+<br>
+<details>
+<summary>click to show other installation options</summary>
+
+```bash
+## Install the latest version using `Cargo.lock` in `~/.rustracer/bin`
+export PREFIX='~/.rustracer/'
+cargo install --locked --root $PREFIX rustracer
+
+## Install the `0.4.0` version in `~/.rustracer/bin`
+export VER='0.4.0'
+export PREFIX='~/.rustracer/'
+cargo install --root $PREFIX --version $VER rustracer
+```
+</details>
+
+<p id="note3"><sub><strong><sup>(3)</sup> note:</strong> will install latest release in <code>~/.cargo/bin</code></sub></p>
+
+## Usage
+
+### rustracer
+
+| **subcommands**                                   | **description**                               |
+| :------------------------------------------------ | :-------------------------------------------- |
+| [**rustracer-convert**](#rustracer-convert)       | convert an hdr image into ldr image           |
+| [**rustracer-demo**](#rustracer-demo)             | render a simple demo scene (example purpose)  |
+| [**rustracer-render**](#rustracer-render)         | render a scene from file (yaml formatted)     |
+| [**rustracer-completion**](#rustracer-completion) | generate shell completion script (hidden)     |
+
+<br>
+<details>
+<summary>click to show <strong>rustracer -h </strong></summary>
+
+```console
+{{ rustracer }}
+```
+</details>
+
+<div align="center"> <hr width="30%"> </div>
+
+### rustracer-convert
+
+Convert a pfm file to png:
+
+<h5>
+   <code>rustracer convert image.pfm image.png</code>
+</h5>
+
+<br>
+<details>
+<summary>click to show <strong>rustracer-convert -h </strong></summary>
+
+```console
+{{ rustracer_convert }}
+```
+</details>
+
+<div align="center"> <hr width="30%"> </div>
+
+### rustracer-demo
+
+Rendering demo scene:
+
+<div align="center">
+   <h5>
+      <code>
+         rustracer demo --width 1920 --height 1080 --anti-aliasing 3 demo.png
+      </code>&nbsp;&nbsp;<a href="#note4"><sup>(4)</sup></a>
+   </h5>
+   <img src="https://github.com/andros21/rustracer/raw/master/examples/demo.png" width="500" alt="rustracer-demo-png"/>
+   <p><sub><strong>demo.png:</strong> cpu Intel(R) Xeon(R) CPU E5520 @ 2.27GHz | threads 8 | time ~35s
+</div>
+
+\
+demo scene 360 degree (see [`makefile`](https://github.com/andros21/rustracer/blob/master/makefile)):
+
+<div align="center">
+  <h5>
+      <code>make demo.gif</code>&nbsp;&nbsp;<a href="#note4"><sup>(4)</sup></a>
+  </h5>
+  <img src="https://github.com/andros21/rustracer/raw/master/examples/demo.gif" width="500" alt="rustracer-demo-gif"/>
+  <p><sub><strong>demo.gif:</strong> cpu Intel(R) Xeon(R) CPU E5520 @ 2.27GHz | threads 8 | time ~15m
+</div>
+
+<br>
+<details>
+<summary>click to show <strong>rustracer-demo -h </strong></summary>
+
+```console
+{{ rustracer_demo }}
+```
+</details>
+
+<p id="note4"><sub><strong><sup>(4)</sup> note:</strong> all available threads are used, set <code>RAYON_NUM_THREADS</code> to override</sub></p>
+
+<div align="center"> <hr width="30%"> </div>
+
+### rustracer-render
+
+Rendering demo scene from scene file [`examples/demo.yml`](https://github.com/andros21/rustracer/blob/master/examples/demo.yml):
+
+<h5>
+   <code>rustracer render --anti-aliasing 3 examples/demo.yml demo.png</code>&nbsp;&nbsp;<a href="#note5"><sup>(5)</sup></a>
+</h5>
+
+you can use this example scene to learn how to write your custom scene, ready to be rendered!
+
+But let's unleash the power of a scene encoded in data-serialization language such as yaml\
+Well repetitive scenes could be nightmare to be written, but for these (and more) there is [`cue`](https://github.com/cue-lang/cue)
+
+Let's try to render a 3D fractal, a [sphere-flake](https://en.wikipedia.org/wiki/Koch_snowflake), but without manually write a yaml scene file\
+we can automatic generate it from [`examples/flake.cue`](https://github.com/andros21/rustracer/blob/master/examples/flake.cue)
+
+```bash
+cue eval flake.cue -e "flake" -f flake.cue.yml   # generate yml from cue
+cat flake.cue.yml | sed "s/'//g" > flake.yml     # little tweaks
+wc -l flake.cue flake.yml                        # compare lines number
+   92 flake.cue                                  # .
+ 2750 flake.yml                                  # .
+```
+so with this trick we've been able to condense a scene info from 2750 to 92 lines, x30 shrink! 😎\
+and the generated `flake.yml` can be simple parsed
+
+<div align="center">
+   <h5>
+   <code>rustracer render --width 1280 --height 720 --anti-aliasing 3 flake.yml flake.png</code>&nbsp;&nbsp;<a href="#note5"><sup>(5)</sup></a>
+   </h5>
+  <img src="https://github.com/andros21/rustracer/raw/master/examples/flake.png" width="500" alt="rustracer-flake"/>
+  <p><sub><strong>flake.png:</strong> cpu Intel(R) Xeon(R) CPU E5520 @ 2.27GHz | threads 8 | time ~7h
+</div>
+
+<br>
+<details>
+<summary>click to show <strong>rustracer-render -h </strong></summary>
+
+```console
+{{ rustracer_render }}
+```
+</details>
+
+<p id="note5"><sub><strong><sup>(5)</sup> note:</strong> all available threads are used, set <code>RAYON_NUM_THREADS</code> to override</sub></p>
+
+<div align="center"> <hr width="30%"> </div>
+
+### rustracer-completion
+
+Simple generate completion script for `bash` shell (same for `fish` and `zsh`):
+
+<div align="center">
+   <h5>
+      <code>rustracer completion bash</code> <a href="#note6"><sup>(6)</sup></a>
+   </h5>
+   <a href="https://asciinema.org/a/1lqL4683WLvXPfOo5W608je6V?autoplay=1&speed1.5" target="_blank"><img src="https://asciinema.org/a/1lqL4683WLvXPfOo5W608je6V.svg" width="500" /></a>
+   <p><sub><strong>note:</strong> close-open your shell, and here we go, tab completions now available!
+</div>
+
+<br>
+<details>
+<summary>click to show <strong>rustracer-completion -h </strong></summary>
+
+```console
+{{ rustracer_completion }}
+```
+</details>
+
+<p id="note6"><sub><strong><sup>(6)</sup> note:</strong> <code>bash>4.1</code> and <code>bash-complete>2.9</code></sub></p>
+
+<div align="center"> <hr width="30%"> </div>
+
+## Acknowledgements
+
+* [pytracer](https://github.com/ziotom78/pytracer) - a simple raytracer in pure Python


### PR DESCRIPTION
it's wonderful to have `rustracer` and its subcommands help msgs inside `README.md` with an optional click but ...

now if there is a cli update the devel must patch manually (copy+paste) the help messages inside `README.md` 
this could leads to inconsistencies between cli and docs

so this pr try to solve this fragile step, automatically updating `README.md` console help output from `TEMPLATE.md` (jinja template) before releasing and deploying, see `cd.yml` changes

the side effects is that if this pr will be merged, `README.md` will be controlled only by github actions, "human" changes must be added to `TEMPLATE.md`