### PR TITLE
build(Cargo.toml): bump rust from 1.65 to 1.66

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
           COVERAGE=$(cat coverage.json \
              | jq -r ".data[0] | .totals | .lines | .percent" \
              | awk '{print int($0)}')
-          echo "##[set-output name=coverage;]${COVERAGE}"
+          echo "coverage=${COVERAGE}" >> $GITHUB_OUTPUT
       - name: cargo test coverage (xml)
         if: ${{ (github.event_name == 'pull_request') && (github.actor != 'dependabot[bot]') }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,17 +170,26 @@ jobs:
              | jq -r ".data[0] | .totals | .lines | .percent" \
              | awk '{print int($0)}')
           echo "##[set-output name=coverage;]${COVERAGE}"
-      - name: cargo test coverage (lcov)
+      - name: cargo test coverage (xml)
         if: ${{ (github.event_name == 'pull_request') && (github.actor != 'dependabot[bot]') }}
         run: |
-          cargo llvm-cov --locked --tests --lcov --output-path coverage.lcov.info
-      - name: lcov pr report
+          cargo llvm-cov --locked --tests --cobertura --output-path coverage.xml
+      - name: cov summary md
         if: ${{ (github.event_name == 'pull_request') && (github.actor != 'dependabot[bot]') }}
-        uses: romeovs/lcov-reporter-action@dda1c9b1fa1622b225e9acd87a248751dbcc6ada
+        uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95
         with:
-          title: Coverage Report
-          filter-changed-files: true
-          lcov-file: coverage.lcov.info
+          filename: coverage.xml
+          format: 'markdown'
+          hide_complexity: true
+          hide_branch_rate: true
+          output: both
+      - name: cov pr comment
+        if: ${{ (github.event_name == 'pull_request') && (github.actor != 'dependabot[bot]') }}
+        uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1
+        with:
+          message: Coverage Report
+          recreate: true
+          path: code-coverage-results.md
   badge:
     name: coverage badge
     needs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name         = "rustracer"
 license      = "GPL-3.0"
 version      = "1.0.1"
 edition      = "2021"
-rust-version = "1.65"
+rust-version = "1.66"
 authors      = [
    "Andrea Rossoni <andrea dot ros.21 at e.email>",
    "Paolo Azzini <paolo dot azzini1 at gmail.com>"

--- a/src/random.rs
+++ b/src/random.rs
@@ -39,7 +39,7 @@ impl Pcg {
         self.state = old_state.wrapping_mul(6364136223846793005) + self.inc;
         let xor_shifted = (((old_state >> 18) ^ old_state) >> 27) as u32;
         let rot = old_state >> 59;
-        (xor_shifted >> rot) as u32 | (xor_shifted << ((-(rot as i64)) & 31))
+        (xor_shifted >> rot) | (xor_shifted << ((-(rot as i64)) & 31))
     }
 
     /// Generates a float random number.

--- a/src/render.rs
+++ b/src/render.rs
@@ -268,7 +268,7 @@ mod test {
             ..Default::default()
         };
         let mut world = World::default();
-        world.add(Box::new(Sphere::default()));
+        world.add(Box::<Sphere>::default());
         let onoff_renderer = Renderer::OnOff(OnOffRenderer::new(&world, BLACK, WHITE));
         assert!(onoff_renderer.solve(ray1, &mut pcg).is_close(BLACK));
         assert!(onoff_renderer.solve(ray2, &mut pcg).is_close(WHITE))

--- a/src/world.rs
+++ b/src/world.rs
@@ -61,7 +61,7 @@ mod test {
     #[test]
     fn test_world() {
         let mut world = World::default();
-        world.add(Box::new(Sphere::default()));
+        world.add(Box::<Sphere>::default());
         world.add(Box::new(Sphere::new(
             translation(E1 * 4.) * scaling(Vector::from((2., 2., 2.))),
             Material {


### PR DESCRIPTION
see https://github.com/rust-lang/rust/releases/tag/1.66.0
see https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-166 (some warnings)