### PR TITLE
build!(TEMPLATE.md): bump glibc requirements from 2.27 to 2.35

### DIFF
--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -44,7 +44,7 @@
 * `x86_64-unknown-linux-gnu` <a href="#note1"><sup>(1)</sup></a>
 * `x86_64-unknown-linux-musl`
 
-<p id="note1"><sub><strong><sup>(1)</sup> note:</strong> glibc version >= 2.27</sub></p>
+<p id="note1"><sub><strong><sup>(1)</sup> note:</strong> glibc version >= 2.35</sub></p>
 
 ### Build requirements
 


### PR DESCRIPTION
**breaking_change**
cause now ubuntu-latest runner is ubuntu 22.04 lts aka jammy see https://github.com/actions/runner-images/issues/6399 so `rustracer-unknown-linux-gnu` will be built with `glibc==2.35` on next patch release