### PR TITLE
build!(rustracer): bump crate from 1.0.1 to 1.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "rustracer"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "byteorder",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name         = "rustracer"
 license      = "GPL-3.0"
-version      = "1.0.1"
+version      = "1.0.2"
 edition      = "2021"
 rust-version = "1.66"
 authors      = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name         = "rustracer"
 license      = "GPL-3.0"
 version      = "1.0.2"
 edition      = "2021"
-rust-version = "1.66"
+rust-version = "1.66.1"
 authors      = [
    "Andrea Rossoni <andrea dot ros.21 at e.email>",
    "Paolo Azzini <paolo dot azzini1 at gmail.com>"

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -44,7 +44,7 @@
 * `x86_64-unknown-linux-gnu` <a href="#note1"><sup>(1)</sup></a>
 * `x86_64-unknown-linux-musl`
 
-<p id="note1"><sub><strong><sup>(1)</sup> note:</strong> glibc version >= 2.27</sub></p>
+<p id="note1"><sub><strong><sup>(1)</sup> note:</strong> glibc version >= 2.35</sub></p>
 
 ### Build requirements
 


### PR DESCRIPTION
prepare for 1.0.2 patch release,
release cause multiple deps have been upgraded since last release

**breaking_change**
cause now ubuntu-latest runner is ubuntu 22.04 lts aka jammy see https://github.com/actions/runner-images/issues/6399 so `rustracer-unknown-linux-gnu` requires at least `glibc>=2.35`