### PR TITLE
build(cd.sh): fix file extension in release script

### DIFF
--- a/.github/workflows/cd.sh
+++ b/.github/workflows/cd.sh
@@ -26,7 +26,7 @@ _assemble() {
 _cosign() {
    for PLATFORM in "${PLATFORMS[@]}"
    do
-      cosign sign-blob "${BASENAME}-${PLATFORM}.targ.gz" \
+      cosign sign-blob "${BASENAME}-${PLATFORM}.tar.gz" \
          --output-signature "${BASENAME}-${PLATFORM}-keyless.sig" \
          --output-certificate "${BASENAME}-${PLATFORM}-keyless.pem"
    done


### PR DESCRIPTION
error introduced in https://github.com/andros21/rustracer/pull/115