### PR TITLE
build(cd.sh): fix forgotten tar.gz extension in release script

### DIFF
--- a/.github/workflows/cd.sh
+++ b/.github/workflows/cd.sh
@@ -5,7 +5,7 @@
 # `rustracer` continuos deployment workflow (`cd.yml`) helper script,
 # it assemble, checksum and (co)sign artifacts for releases
 
-set -e
+set -xe
 
 PLATFORMS=("x86_64-unknown-linux-gnu" "x86_64-unknown-linux-musl")
 BASENAME="rustracer-${GITHUB_REF_NAME}"
@@ -27,8 +27,8 @@ _cosign() {
    for PLATFORM in "${PLATFORMS[@]}"
    do
       cosign sign-blob "${BASENAME}-${PLATFORM}.tar.gz" \
-         --output-signature "${BASENAME}-${PLATFORM}-keyless.sig" \
-         --output-certificate "${BASENAME}-${PLATFORM}-keyless.pem"
+         --output-signature "${BASENAME}-${PLATFORM}.tar.gz-keyless.sig" \
+         --output-certificate "${BASENAME}-${PLATFORM}.tar.gz-keyless.pem"
    done
    cosign sign-blob "${CHECKSUM}" \
       --output-signature "${CHECKSUM}-keyless.sig" \


### PR DESCRIPTION
again! an error introduced in https://github.com/andros21/rustracer/pull/115

the new release [1.0.2](https://github.com/andros21/rustracer/releases/tag/1.0.2) affected by this bug it's now ok, I renamed manually the attachments with wrong name