### PR TITLE
build(Cargo.toml): bump rust from 1.69 to 1.70

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rustracer"
 license = "GPL-3.0"
 version = "1.0.2"
 edition = "2021"
-rust-version = "1.69.0"
+rust-version = "1.70.0"
 authors = [
   "Andrea Rossoni <andrea dot ros.21 at e.email>",
   "Paolo Azzini <paolo dot azzini1 at gmail.com>",


### PR DESCRIPTION
see https://github.com/rust-lang/rust/releases/tag/1.70.0