### PR TITLE
chore(rust-toolchain): override default toolchain

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,12 +26,10 @@ jobs:
             ~/.cargo/
             ~/.rustup/
             target/
-          key: ${{ runner.os }}-rust-musl-${{ hashFiles('Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}
-      - name: install rust toolchain
-        if: steps.rust-cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-unknown-linux-musl
+          key: ${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}
+      - name: add musl target
+        run: |
+          rustup target add x86_64-unknown-linux-musl
       - name: cargo release
         run: |
           cargo build --locked --release --target x86_64-unknown-linux-gnu --target x86_64-unknown-linux-musl
@@ -84,12 +82,7 @@ jobs:
             ~/.cargo/
             ~/.rustup/
             target/
-          key: ${{ runner.os }}-rust-all-${{ hashFiles('Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}
-      - name: install rust toolchain
-        if: steps.cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt, rust-docs
+          key: ${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}
       - name: cargo publish
         run: |
           cargo publish --locked
@@ -113,12 +106,7 @@ jobs:
             ~/.cargo/
             ~/.rustup/
             target/
-          key: ${{ runner.os }}-rust-all-${{ hashFiles('Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}
-      - name: install rust toolchain
-        if: steps.cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, llvm-tools-preview, rustfmt, rust-docs
+          key: ${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}
       - name: patch and cargo rustdoc
         run: make rust_docs
       - name: publish to gh-pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
               - 'Cargo.lock'
               - 'Cargo.toml'
               - 'TEMPLATE.md'
+              - 'rust-toolchain.toml'
             python:
               - '**/*.py'
               - '.github/workflows/requirements.txt'
@@ -55,6 +56,7 @@ jobs:
               - '**/*.rs'
               - 'Cargo.lock'
               - 'Cargo.toml'
+              - 'rust-toolchain.toml'
   lint_rs:
     name: lint rust ci
     needs: changes
@@ -73,12 +75,7 @@ jobs:
             ~/.cargo/
             ~/.rustup/
             target/
-          key: ${{ runner.os }}-rust-all-${{ hashFiles('Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}
-      - name: install rust toolchain
-        if: steps.cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt, rust-docs
+          key: ${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}
       - name: cargo fmt check
         run: |
           cargo fmt -- --check --verbose
@@ -146,12 +143,7 @@ jobs:
             ~/.cargo/
             ~/.rustup/
             target/
-          key: ${{ runner.os }}-rust-all-${{ hashFiles('Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}
-      - name: install rust toolchain
-        if: steps.cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt, rust-docs
+          key: ${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}
       - name: install cargo-tarpaulin
         uses: taiki-e/install-action@ba7482c6af6681ab4e26be5ea509d1e8f7cf6816
         with:
@@ -231,12 +223,7 @@ jobs:
             ~/.cargo/
             ~/.rustup/
             target/
-          key: ${{ runner.os }}-rust-all-${{ hashFiles('Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}
-      - name: install rust toolchain
-        if: steps.cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt, rust-docs
+          key: ${{ runner.os }}-${{ hashFiles('rust-toolchain.toml') }}-${{ hashFiles('Cargo.toml') }}-${{ hashFiles('Cargo.lock') }}
       - name: cargo build
         run: |
           cargo build --locked

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "rustracer"
 license = "GPL-3.0"
 version = "1.0.2"
 edition = "2021"
-rust-version = "1.72.0"
 authors = [
    "Andrea Rossoni <andrea dot ros.21 at e.email>",
    "Paolo Azzini <paolo dot azzini1 at gmail.com>",

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -51,9 +51,9 @@
 
 ### Build requirements
 
-* for **users** install [`cargo`](https://github.com/rust-lang/cargo/) stable latest build system
+* for **users** install [`cargo`](https://github.com/rust-lang/cargo/) stable latest build system (see [`rust-toolchain.toml`](https://github.com/andros21/rustracer/blob/master/rust-toolchain.toml) for stable version)
 
-* for **devels** it's advisable to install the entire (stable latest) toolchain using [`rustup`](https://www.rust-lang.org/tools/install)
+* for **devels** install [`rustup`](https://www.rust-lang.org/tools/install) that will automatically provision the correct toolchain
 
    For unit tests coverage `llvm-tools-preview` is required as additional component coupled with\
    [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) for easily use LLVM source-based code coverage

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.72.0"
+components = ["clippy", "rustfmt", "rust-docs"]
+profile = "minimal"


### PR DESCRIPTION
in this way `rustup` should install the correct toolchain if not cached and then run cargo commands

this also makes useless:
 * `dtolnay/rust-toolchain` action
 * stupid manifest `rust-version` monthly bump, field that is completely irrelevant to force the particular toolchain version during development