### PR TITLE
Attach SLSA3+ provenance to releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
     steps:
       - name: checkout project
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
@@ -32,7 +34,13 @@ jobs:
           cargo build --locked --release --target x86_64-unknown-linux-gnu --target x86_64-unknown-linux-musl
       - name: assemble artifacts
         run: .github/workflows/cd.sh assemble
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+      - name: generate subject
+        id: hash
+        run: |
+          set -euo pipefail
+          echo "hashes=$(cat rustracer-*.txt | base64 -w0)" >> "$GITHUB_OUTPUT"
+      - name: upload artifacts
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
         with:
           name: rustracer-build
           path: |
@@ -44,8 +52,10 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       id-token: write
       contents: write
+    needs: build
     steps:
       - name: checkout project
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
@@ -80,6 +90,18 @@ jobs:
             rustracer-*.txt
             rustracer-*.pem
             rustracer-*.sig
+  provenance:
+    needs:
+      - build
+      - release
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@07e64b653f10a80b6510f4568f685f8b7b9ea830
+    with:
+      base64-subjects: "${{ needs.build.outputs.hashes }}"
+      upload-assets: true
   cratesio:
     name: cratesio
     runs-on: ubuntu-latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,17 +7,14 @@ name: CD
       - "[0-9].[0-9].[0-9]+"
 
 jobs:
-  release:
-    name: release
+  build:
+    name: build
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
-      contents: write
+      contents: read
     steps:
       - name: checkout project
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-        with:
-          fetch-depth: 0
       - name: check cargo cache
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
         id: rust-cache
@@ -35,6 +32,28 @@ jobs:
           cargo build --locked --release --target x86_64-unknown-linux-gnu --target x86_64-unknown-linux-musl
       - name: assemble artifacts
         run: .github/workflows/cd.sh assemble
+      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        with:
+          name: rustracer-build
+          path: |
+            rustracer-*.tar.gz
+            rustracer-*.txt
+          if-no-files-found: error
+          retention-days: 1
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: checkout project
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+        with:
+          name: rustracer-build
       - name: install cosign
         uses: sigstore/cosign-installer@1fc5bd396d372bee37d608f955b336615edf79c8
       - name: cosign artifacts


### PR DESCRIPTION
See https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md#generation-of-slsa3-provenance-for-arbitrary-projects