### PR TITLE
chore(rustracer): bump crate from 1.0.2 to 1.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "rustracer"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "byteorder",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustracer"
 license = "GPL-3.0"
-version = "1.0.2"
+version = "1.0.3"
 edition = "2021"
 authors = [
    "Andrea Rossoni <andrea dot ros.21 at e.email>",


### PR DESCRIPTION
prepare for 1.0.3 patch release,
release cause multiple deps have been upgraded since last release