### PR TITLE
chore(rustracer): bump crate from 1.0.3 to 1.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "rustracer"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "byteorder",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustracer"
 license = "GPL-3.0"
-version = "1.0.3"
+version = "1.0.4"
 edition = "2021"
 authors = [
    "Andrea Rossoni <andrea dot ros.21 at e.email>",


### PR DESCRIPTION
prepare for 1.0.4 patch release