### PR TITLE
chore(rust-toolchain): bump rust to 1.79 (#410)

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.78"
+channel = "1.79"
 components = ["clippy", "rustfmt", "rust-docs"]
 profile = "minimal"


### PR DESCRIPTION
https://github.com/rust-lang/rust/releases/tag/1.79.0