### PR TITLE
chore(rust-toolchain): bump rust to 1.97

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.96.0"
+channel = "1.97.1"
 components = ["clippy", "rustfmt", "rust-docs"]
 profile = "minimal"


### PR DESCRIPTION
see https://github.com/rust-lang/rust/releases/tag/1.97.1